### PR TITLE
Correct an small error (Can't find variable: r)

### DIFF
--- a/components/Calendar.js
+++ b/components/Calendar.js
@@ -173,7 +173,7 @@ export default class Calendar extends Component {
       let sundayMoment = moment(currMoment).startOf('week');
       if (weekStart > 0) {
         res = moment(currMoment).isoWeekday(weekStart);
-        if (r.diff(currMoment) > 0) {
+        if (res.diff(currMoment) > 0) {
           res = moment(currMoment).subtract(7, 'day').isoWeekday(weekStart);
         }
       } else {


### PR DESCRIPTION
At the line 176 in Calendar.js, the variable "r" was not found. I replaced "r" by "res", as declared previously.